### PR TITLE
Center the Steam sign-in error inside the password field

### DIFF
--- a/app/src/main/feature/stores/steam/SteamLoginActivity.kt
+++ b/app/src/main/feature/stores/steam/SteamLoginActivity.kt
@@ -338,14 +338,22 @@ class SteamLoginActivity : FixedFontScaleComponentActivity() {
                             }
                         }),
                 )
-                // Error overlaid at bottom of password field — no layout shift
                 androidx.compose.animation.AnimatedVisibility(
                     visible = showLoginError,
                     enter = fadeIn(tween(200)),
                     exit = fadeOut(tween(150)),
-                    modifier = Modifier.align(Alignment.BottomStart).offset(y = 8.dp),
+                    modifier =
+                        Modifier
+                            .align(Alignment.BottomCenter)
+                            .offset(y = (-2).dp)
+                            .padding(horizontal = 12.dp),
                 ) {
-                    Text(stringResource(R.string.steam_login_invalid_username_or_password), color = DangerRed, fontSize = 11.sp)
+                    Text(
+                        stringResource(R.string.steam_login_invalid_username_or_password),
+                        color = DangerRed,
+                        fontSize = 11.sp,
+                        textAlign = TextAlign.Center,
+                    )
                 }
             }
 


### PR DESCRIPTION
The invalid-credentials message is an overlay on the password field rather than supportingText, so it takes no part in layout. Aligning it to BottomStart pinned its bottom edge to the field's bottom edge, and the 8dp downward offset then pushed it across the outline: the border stroke ran through the text and the first glyph collided with the rounded left corner.

Align to BottomCenter and raise it so it sits inside the field's lower inset, clear of the stroke. Horizontal padding keeps longer translations off the corners.