### PR TITLE
Locate the Lossless DLL with WinNative's file picker

### DIFF
--- a/app/src/main/feature/library/GameSettings.kt
+++ b/app/src/main/feature/library/GameSettings.kt
@@ -59,8 +59,7 @@ import androidx.compose.material.icons.outlined.Extension
 import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.Monitor
 import androidx.compose.material.icons.outlined.Speed
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
+import android.os.Environment
 import androidx.compose.material.icons.outlined.Science
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.SportsEsports
@@ -149,7 +148,10 @@ import com.winlator.cmod.runtime.reshade.ReshadeManager
 import com.winlator.cmod.shared.framegen.FrameGenPreset
 import com.winlator.cmod.shared.theme.GameSettingsStyle
 import com.winlator.cmod.runtime.wine.WineThemeManager
+import com.winlator.cmod.runtime.display.environment.ImageFs
 import com.winlator.cmod.runtime.display.lsfg.LosslessScaling
+import com.winlator.cmod.shared.android.DirectoryPickerDialog
+import com.winlator.cmod.shared.ui.dialog.findActivity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -177,6 +179,7 @@ import com.winlator.cmod.shared.ui.nav.paneHighlight
 import com.winlator.cmod.shared.ui.nav.paneNavItem
 import com.winlator.cmod.shared.ui.widget.EnvVarsView
 import com.winlator.cmod.shared.ui.widget.chasingBorder
+import java.io.File
 import kotlin.math.roundToInt
 
 private val BgDeep = GameSettingsStyle.BgDeep
@@ -1762,16 +1765,38 @@ private fun FrameGenerationCard(state: GameSettingsStateHolder) {
     }
 
     val scope = rememberCoroutineScope()
-    val picker =
-        rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
-            if (uri == null) return@rememberLauncherForActivityResult
-            state.frameGenShaderState.intValue = FRAMEGEN_SHADERS_IMPORTING
-            scope.launch {
-                val outcome = withContext(Dispatchers.IO) { LosslessAutoImport.importFrom(context, uri) }
-                state.frameGenSourceName.value = outcome.sourceName
-                state.frameGenShaderState.intValue = frameGenStateFor(outcome.result)
+    val pickDll = {
+        val activity = context.findActivity()
+        if (activity != null) {
+            val imagefsRoot = ImageFs.find(context).rootDir
+            DirectoryPickerDialog.showFile(
+                activity,
+                title = context.getString(R.string.settings_frame_generation_locate),
+                allowedExtensions = setOf("dll"),
+                extraRoots =
+                    listOf(
+                        DirectoryPickerDialog.ManagedRoot("C:", File(imagefsRoot, "home").absolutePath),
+                        DirectoryPickerDialog.ManagedRoot("Z:", imagefsRoot.absolutePath),
+                        DirectoryPickerDialog.ManagedRoot(
+                            "D:",
+                            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).absolutePath,
+                        ),
+                        DirectoryPickerDialog.ManagedRoot(
+                            "Internal",
+                            Environment.getExternalStorageDirectory().absolutePath,
+                        ),
+                    ),
+            ) { pickedPath ->
+                state.frameGenShaderState.intValue = FRAMEGEN_SHADERS_IMPORTING
+                scope.launch {
+                    val outcome =
+                        withContext(Dispatchers.IO) { LosslessAutoImport.importFrom(context, File(pickedPath)) }
+                    state.frameGenSourceName.value = outcome.sourceName
+                    state.frameGenShaderState.intValue = frameGenStateFor(outcome.result)
+                }
             }
         }
+    }
 
     val shaders = state.frameGenShaderState.intValue
     val ready = shaders == FRAMEGEN_SHADERS_READY || shaders == FRAMEGEN_SHADERS_UPDATED
@@ -1839,7 +1864,7 @@ private fun FrameGenerationCard(state: GameSettingsStateHolder) {
             SettingActionButton(
                 label = stringResource(R.string.settings_frame_generation_locate),
                 enabled = !busy,
-                onClick = { picker.launch(arrayOf("*/*")) },
+                onClick = { pickDll() },
             )
         }
 

--- a/app/src/main/feature/library/LosslessAutoImport.kt
+++ b/app/src/main/feature/library/LosslessAutoImport.kt
@@ -70,6 +70,14 @@ object LosslessAutoImport {
         return Outcome(RESULT_IMPORTED, uri.lastPathSegment?.substringAfterLast('/').orEmpty())
     }
 
+    fun importFrom(context: Context, dll: File): Outcome {
+        val name = dll.parentFile?.name?.takeIf { it.isNotBlank() } ?: dll.name
+        if (!isOwned()) return Outcome(RESULT_NOT_OWNED, name)
+        val status = LosslessScaling.installFrom(context, dll)
+        if (status != LosslessScaling.STATUS_OK) return Outcome(RESULT_FAILED, name)
+        return Outcome(RESULT_IMPORTED, name)
+    }
+
     private fun steamCandidateDirs(): List<File> {
         val dirs = LinkedHashSet<File>()
 

--- a/app/src/main/shared/ui/dialog/WinNativeComposeDialogs.kt
+++ b/app/src/main/shared/ui/dialog/WinNativeComposeDialogs.kt
@@ -230,7 +230,7 @@ object WinNativeComposeDialogs {
         }
 }
 
-private tailrec fun Context.findActivity(): Activity? =
+internal tailrec fun Context.findActivity(): Activity? =
     when (this) {
         is Activity -> this
         is android.content.ContextWrapper -> baseContext.findActivity()


### PR DESCRIPTION
The Locate button on the frame generation card opened Android's document picker, which shows storage through SAF. Lossless.dll lives inside a container's drive_c, and SAF has no view of the imagefs, so reaching it meant copying the DLL out to Downloads first. WinNative already ships a browser that mounts those drives.

Open DirectoryPickerDialog.showFile instead, filtered to .dll and given the same C:/Z:/D:/Internal roots the container saves import uses, so the wineprefix is reachable directly. The picker hands back a path rather than a content URI, so add a File overload to LosslessAutoImport.importFrom that goes straight to LosslessScaling.installFrom(Context, File) and skips staging a copy in the cache dir. The reported source name is the containing folder, matching what the automatic Steam import already reports.

findActivity moves from private to internal so the Compose card can resolve the host activity the dialog needs.