### PR TITLE
Stop repeating per-launch work that cannot change its own result

### DIFF
--- a/app/src/main/feature/stores/steam/utils/SteamUtils.kt
+++ b/app/src/main/feature/stores/steam/utils/SteamUtils.kt
@@ -886,7 +886,7 @@ object SteamUtils {
                 return
             }
             val gameName = gameDir.name
-            val sizeOnDisk = calculateDirectorySize(gameDir)
+            val sizeOnDisk = installSizeOnDisk(context, steamAppId, gameDir)
             val selectedBranch = SteamService.resolveSelectedBetaName(steamAppId).ifBlank { "public" }
             val ownerSteamId = PrefManager.steamUserSteamId64.takeIf { it > 0L }?.toString() ?: "0"
 
@@ -1184,6 +1184,105 @@ object SteamUtils {
         if (input == null) return ""
         return input.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r")
     }
+
+    private const val INSTALL_SCAN_PREFS = "steam_install_size_cache"
+
+    class InstallScan(
+        @JvmField val sizeOnDisk: Long,
+        @JvmField val hasSteamApiOrig: Boolean,
+    )
+
+    private val installScanMemo = java.util.concurrent.ConcurrentHashMap<String, Pair<String, InstallScan>>()
+
+    private fun installScanKey(appId: Int, gameDir: File) = "$appId:${gameDir.absolutePath}"
+
+    private fun installScanSignature(appId: Int, gameDir: File): String {
+        val branch = SteamService.resolveSelectedBetaName(appId).ifBlank { "public" }
+        val appInfo = getAppInfoOf(appId)
+        val buildId =
+            appInfo?.branches?.get(branch)?.buildId
+                ?: appInfo?.branches?.get("public")?.buildId
+                ?: 0L
+        val depots = SteamService.getInstalledDepotsOf(appId).orEmpty().sorted().joinToString(",")
+        val dlc = SteamService.getInstalledDlcDepotsOf(appId).orEmpty().sorted().joinToString(",")
+        return "$buildId|${gameDir.lastModified()}|$depots|$dlc"
+    }
+
+    @JvmStatic
+    fun invalidateInstallScan(
+        context: Context,
+        appId: Int,
+        gameDir: File?,
+    ) {
+        if (gameDir == null) return
+        val cacheKey = installScanKey(appId, gameDir)
+        installScanMemo.remove(cacheKey)
+        context.getSharedPreferences(INSTALL_SCAN_PREFS, Context.MODE_PRIVATE)
+            .edit().remove(cacheKey).apply()
+        Timber.i("invalidateInstallScan($cacheKey)")
+    }
+
+    @JvmStatic
+    fun scanInstall(
+        context: Context,
+        appId: Int,
+        gameDir: File?,
+    ): InstallScan {
+        if (gameDir == null || !gameDir.isDirectory) return InstallScan(0L, false)
+
+        val cacheKey = installScanKey(appId, gameDir)
+        val signature = installScanSignature(appId, gameDir)
+
+        installScanMemo[cacheKey]?.let { (cachedSignature, cachedScan) ->
+            if (cachedSignature == signature) return cachedScan
+        }
+
+        val prefs = context.getSharedPreferences(INSTALL_SCAN_PREFS, Context.MODE_PRIVATE)
+        prefs.getString(cacheKey, null)?.let { stored ->
+            val parts = stored.split('#')
+            if (parts.size == 3) {
+                val storedSize = parts[1].toLongOrNull()
+                if (parts[0] == signature && storedSize != null) {
+                    val scan = InstallScan(storedSize, parts[2].toBoolean())
+                    installScanMemo[cacheKey] = signature to scan
+                    Timber.i("scanInstall($cacheKey): cache hit, no directory walk")
+                    return scan
+                }
+            }
+        }
+
+        val started = System.currentTimeMillis()
+        var size = 0L
+        var hasOrig = false
+        try {
+            gameDir.walkTopDown().forEach { file ->
+                if (file.isFile) {
+                    size += file.length()
+                    val name = file.name.lowercase()
+                    if (name == "steam_api.dll.orig" || name == "steam_api64.dll.orig") hasOrig = true
+                }
+            }
+        } catch (e: Exception) {
+            Timber.w(e, "scanInstall($cacheKey) failed; not caching")
+            return InstallScan(size, true)
+        }
+        Timber.i(
+            "scanInstall($cacheKey): walked in ${System.currentTimeMillis() - started}ms " +
+                "-> $size bytes, hasSteamApiOrig=$hasOrig",
+        )
+
+        val scan = InstallScan(size, hasOrig)
+        installScanMemo[cacheKey] = signature to scan
+        prefs.edit().putString(cacheKey, "$signature#$size#$hasOrig").apply()
+        return scan
+    }
+
+    @JvmStatic
+    fun installSizeOnDisk(
+        context: Context,
+        appId: Int,
+        gameDir: File?,
+    ): Long = scanInstall(context, appId, gameDir).sizeOnDisk
 
     private fun calculateDirectorySize(directory: File): Long {
         if (!directory.exists() || !directory.isDirectory) {

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -293,6 +293,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity
     private boolean rendererWindowPresented;
     private Runnable editInputControlsCallback;
     private Shortcut shortcut;
+    private volatile String appliedSteamClientVisibility = null;
     private boolean launchedFromPinnedShortcut = false;
     private String graphicsDriver = Container.DEFAULT_GRAPHICS_DRIVER;
     private String zinkMode = Container.DEFAULT_ZINK_MODE;
@@ -6580,6 +6581,8 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity
                 }
 
                 MarkerUtils.INSTANCE.addMarker(gameInstallPath, Marker.STEAM_COLDCLIENT_USED);
+                com.winlator.cmod.feature.stores.steam.utils.SteamUtils
+                        .invalidateInstallScan(this, appId, gameDir);
             } else if (isBionicSteamEnabledForShortcut()) {
                 MarkerUtils.INSTANCE.removeMarker(gameInstallPath, Marker.STEAM_DLL_REPLACED);
                 MarkerUtils.INSTANCE.removeMarker(gameInstallPath, Marker.STEAM_COLDCLIENT_USED);
@@ -6610,11 +6613,21 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity
                 }
 
                 if (wnPlanWActive) {
-                    restoreSteamApiDlls(gameDir);
+                    if (com.winlator.cmod.feature.stores.steam.utils.SteamUtils
+                            .scanInstall(this, appId, gameDir).hasSteamApiOrig) {
+                        restoreSteamApiDlls(gameDir);
+                        com.winlator.cmod.feature.stores.steam.utils.SteamUtils
+                                .invalidateInstallScan(this, appId, gameDir);
+                    } else {
+                        Log.d("XServerDisplayActivity",
+                                "Steam Launcher: install has no steam_api .orig backups — skipping restore walk");
+                    }
                 } else {
                     int steampipeSwapped = com.winlator.cmod.feature.stores.steam.wnsteam
                             .WnSteamAssetsInstaller.INSTANCE
                             .installSteampipeBridgeIntoApp(this, gameDir);
+                    com.winlator.cmod.feature.stores.steam.utils.SteamUtils
+                            .invalidateInstallScan(this, appId, gameDir);
                     Log.d("XServerDisplayActivity",
                             "Bionic Steam: " + steampipeSwapped
                             + " steam_api*.dll(s) replaced with steampipe bridge");
@@ -6844,15 +6857,15 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity
                 exclusiveXInput = extra.equals("1");
             }
         }
-        WineUtils.setJoystickRegistryKeys(container, dinputEnabled, exclusiveXInput);
-        WineUtils.ensureWinebusConfig(container);
-
         if (shortcut != null)
             startupSelection = getShortcutSetting("startupSelection", String.valueOf(container.getStartupSelection()));
         else
             startupSelection = String.valueOf(container.getStartupSelection());
 
-        WineUtils.changeServicesStatus(container, startupSelection);
+        if (WineUtils.applyLaunchRegistryPolicy(
+                container, startupSelection, dinputEnabled, exclusiveXInput, firstTimeBoot)) {
+            containerDataChanged = true;
+        }
         if (!startupSelection.equals(container.getExtra("startupSelection"))) {
             container.putExtra("startupSelection", startupSelection);
             containerDataChanged = true;
@@ -7396,26 +7409,10 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity
                                 }
                                 envVars.put("WN_STEAM_BUILD_ID", String.valueOf(buildId));
 
-                                // Compute sizeOnDisk recursively from game directory (match Kotlin
-                                // calculateDirectorySize); null-guard listFiles() so a transient I/O
-                                // error never NPEs and silently drops all depot data.
                                 String gameInstallPath = resolveSteamGameInstallPath(bsAppId);
-                                long sizeOnDisk = 0L;
-                                if (gameInstallPath != null) {
-                                    java.util.ArrayDeque<java.io.File> stack = new java.util.ArrayDeque<>();
-                                    stack.push(new java.io.File(gameInstallPath));
-                                    while (!stack.isEmpty()) {
-                                        java.io.File cur = stack.pop();
-                                        if (cur.isDirectory()) {
-                                            java.io.File[] children = cur.listFiles();
-                                            if (children != null) {
-                                                for (java.io.File c : children) stack.push(c);
-                                            }
-                                        } else if (cur.isFile()) {
-                                            sizeOnDisk += cur.length();
-                                        }
-                                    }
-                                }
+                                long sizeOnDisk = com.winlator.cmod.feature.stores.steam.utils
+                                        .SteamUtils.installSizeOnDisk(this, bsAppId,
+                                                gameInstallPath != null ? new java.io.File(gameInstallPath) : null);
                                 envVars.put("WN_STEAM_SIZE_ON_DISK", String.valueOf(sizeOnDisk));
 
                                 // Collect installed depot IDs and DLC app IDs (same as Kotlin collectInstalledDepotManifests)
@@ -10893,6 +10890,13 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity
 
     private void setSteamClientVisibility(boolean visible, boolean coldClientMode) {
         if (container == null) return;
+        String requested = container.id + ":" + visible + ":" + coldClientMode;
+        if (requested.equals(appliedSteamClientVisibility)) {
+            Log.d("XServerDisplayActivity",
+                    "Steam client visibility already applied this session (" + requested + "), skipping");
+            return;
+        }
+        appliedSteamClientVisibility = requested;
         updateSteamDirectoryVisibility(visible, coldClientMode);
         updateSteamRegistryVisibility(visible);
     }

--- a/app/src/main/runtime/wine/WineRegistryEditor.java
+++ b/app/src/main/runtime/wine/WineRegistryEditor.java
@@ -235,6 +235,19 @@ public class WineRegistryEditor implements Closeable {
     return success ? unescape(new String(buffer)) : null;
   }
 
+  private boolean isValueUnchanged(Location valueLocation, String value) {
+    if (valueLocation.length() != value.length()) return false;
+    char[] existing = new char[valueLocation.length()];
+    try (BufferedReader reader =
+        new BufferedReader(new FileReader(cloneFile), StreamUtils.BUFFER_SIZE)) {
+      reader.skip(valueLocation.start);
+      if (reader.read(existing) != existing.length) return false;
+    } catch (IOException e) {
+      return false;
+    }
+    return value.contentEquals(new String(existing));
+  }
+
   private void setRawValue(String key, String name, String value) {
     resetLastParentKeyPositionIfNeed(key);
 
@@ -250,6 +263,8 @@ public class WineRegistryEditor implements Closeable {
     }
 
     Location valueLocation = getValueLocation(keyLocation, name);
+    if (valueLocation != null && value != null && isValueUnchanged(valueLocation, value)) return;
+
     char[] buffer = new char[StreamUtils.BUFFER_SIZE];
     boolean success = false;
 

--- a/app/src/main/runtime/wine/WineUtils.java
+++ b/app/src/main/runtime/wine/WineUtils.java
@@ -1392,6 +1392,40 @@ public abstract class WineUtils {
     }
   }
 
+  private static final int LAUNCH_REGISTRY_POLICY_VERSION = 1;
+
+  private static final String LAUNCH_REGISTRY_POLICY_EXTRA = "launchRegistryPolicy";
+
+  public static boolean applyLaunchRegistryPolicy(
+      Container container,
+      String startupSelection,
+      boolean dinputEnabled,
+      boolean exclusiveXInput,
+      boolean force) {
+    if (container == null) return false;
+
+    String stamp =
+        LAUNCH_REGISTRY_POLICY_VERSION
+            + "|"
+            + startupSelection
+            + "|"
+            + (dinputEnabled ? 1 : 0)
+            + "|"
+            + (exclusiveXInput ? 1 : 0);
+
+    if (!force && stamp.equals(container.getExtra(LAUNCH_REGISTRY_POLICY_EXTRA))) {
+      Log.d("ContainerLaunch", "applyLaunchRegistryPolicy: unchanged (" + stamp + "), skipping");
+      return false;
+    }
+
+    setJoystickRegistryKeys(container, dinputEnabled, exclusiveXInput);
+    ensureWinebusConfig(container);
+    changeServicesStatus(container, startupSelection);
+    container.putExtra(LAUNCH_REGISTRY_POLICY_EXTRA, stamp);
+    Log.d("ContainerLaunch", "applyLaunchRegistryPolicy: applied (" + stamp + " force=" + force + ")");
+    return true;
+  }
+
   public static void changeServicesStatus(Container container, String startupSelection) {
     String[] services = {
       "BITS:3",


### PR DESCRIPTION
Four pieces of launch-time work re-ran on every game start and always produced byte-identical results.

WineRegistryEditor.setRawValue rewrote the entire .reg file to a temp file and renamed it without ever comparing against the existing value, so writing an already-correct value cost a full read plus a full write. changeServicesStatus (23 services x 3 control sets), ensureWinebusConfig and setJoystickRegistryKeys then ran ungated on every launch: ~4s on a 3.6MB system.reg. The gate existed but only decided whether to saveData(), after the writes had already happened. Compare before writing, and gate the three passes behind applyLaunchRegistryPolicy, which fingerprints startupSelection, dinput and exclusiveXInput into a container extra. firstTimeBoot forces a re-apply; bump LAUNCH_REGISTRY_POLICY_VERSION when the service list changes.

createAppManifest, setupXEnvironment and restoreSteamApiDlls each walked the whole game install directory. The first two computed the same sizeOnDisk via two separate implementations; the third hunted steam_api .orig backups that normally do not exist and logged nothing while doing it. On a 10.3GB, 51,640-file install that was 5.4s + 6.0s + 7.6s per launch. Replace all three with SteamUtils.scanInstall, which walks once and returns size plus hasSteamApiOrig, memoized in process and persisted in prefs under a buildId + mtime + depots + DLC signature. restoreSteamApiDlls now runs only when the scan found something to restore, and every DLL injection path invalidates the entry. A failed scan reports hasSteamApiOrig and is not cached, so errors fail toward doing the work.

setSteamClientVisibility also ran twice per Steam launch; it is now applied once per session.

Measured on a OnePlus Pad 2 launching Monster Hunter Stories, shortcut resolve to launch complete: 32.8s -> 15.4s. The app's own share fell 20.3s -> 3.8s; the rest is Steam's own logon and LaunchApp. Steam logon, install verification and LaunchApp all still succeed, and the ACF sizeOnDisk is unchanged at 10314781317.