### PR TITLE
dual edge drawers

### DIFF
--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -677,6 +677,9 @@ Por ejemplo, <b>META</b> para la <i>tecla META</i>, \n
     <string name="session_drawer_relative_mouse_movement">Movimiento relativo del mouse</string>
     <string name="session_drawer_mouse_input">Entrada del mouse</string>
     <string name="session_drawer_touch">Toque</string>
+    <string name="session_drawer_layout">Diseño del cajón</string>
+    <string name="session_drawer_layout_items">Elementos de menú</string>
+    <string name="session_drawer_layout_tabs">Pestañas</string>
     <string name="session_drawer_touch_trackpad">Trackpad</string>
     <string name="session_drawer_touch_touchscreen">Modo de pantalla táctil</string>
     <string name="session_drawer_touch_map_right_stick">Asignar a la palanca derecha</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1511,6 +1511,9 @@ Installeret sti:
     <string name="session_drawer_rts_gestures">RTS-gestusser</string>
     <string name="session_drawer_rts_gestures_edit">Rediger</string>
     <string name="session_drawer_touch">Berøring</string>
+    <string name="session_drawer_layout">Skuffelayout</string>
+    <string name="session_drawer_layout_items">Menupunkter</string>
+    <string name="session_drawer_layout_tabs">Faner</string>
     <string name="session_drawer_touch_map_right_stick">Tilknyt højre stik</string>
     <string name="session_drawer_touch_touchscreen">Touchskærm-tilstand</string>
     <string name="session_drawer_touch_trackpad">Pegeplade</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1511,6 +1511,9 @@ Installierter Pfad:
     <string name="session_drawer_rts_gestures">RTS-Gesten</string>
     <string name="session_drawer_rts_gestures_edit">Bearbeiten</string>
     <string name="session_drawer_touch">Touch</string>
+    <string name="session_drawer_layout">Drawer-Layout</string>
+    <string name="session_drawer_layout_items">Menüpunkte</string>
+    <string name="session_drawer_layout_tabs">Registerkarten</string>
     <string name="session_drawer_touch_map_right_stick">Auf rechten Stick mappen</string>
     <string name="session_drawer_touch_touchscreen">Touchscreen-Modus</string>
     <string name="session_drawer_touch_trackpad">Trackpad</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1511,6 +1511,9 @@ Ruta instalada:
     <string name="session_drawer_rts_gestures">Gestos RTS</string>
     <string name="session_drawer_rts_gestures_edit">Editar</string>
     <string name="session_drawer_touch">Táctil</string>
+    <string name="session_drawer_layout">Diseño del cajón</string>
+    <string name="session_drawer_layout_items">Elementos de menú</string>
+    <string name="session_drawer_layout_tabs">Pestañas</string>
     <string name="session_drawer_touch_map_right_stick">Asignar al stick derecho</string>
     <string name="session_drawer_touch_touchscreen">Modo pantalla táctil</string>
     <string name="session_drawer_touch_trackpad">Trackpad</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -677,6 +677,9 @@ E.g. <b>META</b> for <i>META-näppäin</i>, \n
     <string name="session_drawer_relative_mouse_movement">Suhteellinen hiiren liike</string>
     <string name="session_drawer_mouse_input">Hiiren syöte</string>
     <string name="session_drawer_touch">Kosketus</string>
+    <string name="session_drawer_layout">Laatikon asettelu</string>
+    <string name="session_drawer_layout_items">Valikkokohteet</string>
+    <string name="session_drawer_layout_tabs">Välilehdet</string>
     <string name="session_drawer_touch_trackpad">Kosketuslevy</string>
     <string name="session_drawer_touch_touchscreen">Kosketusnäyttötila</string>
     <string name="session_drawer_touch_map_right_stick">Yhdistä oikeaan sauvaan</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1511,6 +1511,9 @@ Chemin installé :
     <string name="session_drawer_rts_gestures">Gestes RTS</string>
     <string name="session_drawer_rts_gestures_edit">Modifier</string>
     <string name="session_drawer_touch">Tactile</string>
+    <string name="session_drawer_layout">Disposition du tiroir</string>
+    <string name="session_drawer_layout_items">Éléments de menu</string>
+    <string name="session_drawer_layout_tabs">Onglets</string>
     <string name="session_drawer_touch_map_right_stick">Mapper sur le stick droit</string>
     <string name="session_drawer_touch_touchscreen">Mode écran tactile</string>
     <string name="session_drawer_touch_trackpad">Trackpad</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1447,6 +1447,9 @@
     <string name="session_drawer_rts_gestures">RTS जेस्चर</string>
     <string name="session_drawer_rts_gestures_edit">संपादित करें</string>
     <string name="session_drawer_touch">टच</string>
+    <string name="session_drawer_layout">ड्रॉअर लेआउट</string>
+    <string name="session_drawer_layout_items">मेनू आइटम</string>
+    <string name="session_drawer_layout_tabs">टैब</string>
     <string name="session_drawer_touch_map_right_stick">दाएँ स्टिक से मैप करें</string>
     <string name="session_drawer_touch_touchscreen">टचस्क्रीन मोड</string>
     <string name="session_drawer_touch_trackpad">ट्रैकपैड</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1511,6 +1511,9 @@ Percorso installato:
     <string name="session_drawer_rts_gestures">Gesti RTS</string>
     <string name="session_drawer_rts_gestures_edit">Modifica</string>
     <string name="session_drawer_touch">Tocco</string>
+    <string name="session_drawer_layout">Layout del cassetto</string>
+    <string name="session_drawer_layout_items">Voci di menu</string>
+    <string name="session_drawer_layout_tabs">Schede</string>
     <string name="session_drawer_touch_map_right_stick">Mappa su stick destro</string>
     <string name="session_drawer_touch_touchscreen">Modalità touchscreen</string>
     <string name="session_drawer_touch_trackpad">Trackpad</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -677,6 +677,9 @@
     <string name="session_drawer_relative_mouse_movement">相対マウス移動</string>
     <string name="session_drawer_mouse_input">マウス入力</string>
     <string name="session_drawer_touch">タッチ</string>
+    <string name="session_drawer_layout">ドロワーレイアウト</string>
+    <string name="session_drawer_layout_items">メニュー項目</string>
+    <string name="session_drawer_layout_tabs">タブ</string>
     <string name="session_drawer_touch_trackpad">トラックパッド</string>
     <string name="session_drawer_touch_touchscreen">タッチスクリーンモード</string>
     <string name="session_drawer_touch_map_right_stick">右スティックに割り当て</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1512,6 +1512,9 @@
     <string name="session_drawer_rts_gestures">RTS 제스처</string>
     <string name="session_drawer_rts_gestures_edit">편집</string>
     <string name="session_drawer_touch">터치</string>
+    <string name="session_drawer_layout">서랍 레이아웃</string>
+    <string name="session_drawer_layout_items">메뉴 항목</string>
+    <string name="session_drawer_layout_tabs">탭</string>
     <string name="session_drawer_touch_map_right_stick">오른쪽 스틱에 매핑</string>
     <string name="session_drawer_touch_touchscreen">터치스크린 모드</string>
     <string name="session_drawer_touch_trackpad">트랙패드</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -677,6 +677,9 @@ F.eks. <b>META</b> for <i>META-tast</i>, \n
     <string name="session_drawer_relative_mouse_movement">Relativ musebevegelse</string>
     <string name="session_drawer_mouse_input">Museinndata</string>
     <string name="session_drawer_touch">Berøring</string>
+    <string name="session_drawer_layout">Skuffelayout</string>
+    <string name="session_drawer_layout_items">Menyelementer</string>
+    <string name="session_drawer_layout_tabs">Faner</string>
     <string name="session_drawer_touch_trackpad">Styreplate</string>
     <string name="session_drawer_touch_touchscreen">Berøringsskjermmodus</string>
     <string name="session_drawer_touch_map_right_stick">Tilordne til høyre spak</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1517,6 +1517,9 @@ Zainstalowana ścieżka:
     <string name="session_drawer_rts_gestures">Gesty RTS</string>
     <string name="session_drawer_rts_gestures_edit">Edytuj</string>
     <string name="session_drawer_touch">Dotyk</string>
+    <string name="session_drawer_layout">Układ szuflady</string>
+    <string name="session_drawer_layout_items">Elementy menu</string>
+    <string name="session_drawer_layout_tabs">Karty</string>
     <string name="session_drawer_touch_map_right_stick">Mapuj na prawą gałkę</string>
     <string name="session_drawer_touch_touchscreen">Tryb ekranu dotykowego</string>
     <string name="session_drawer_touch_trackpad">Gładzik</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1511,6 +1511,9 @@ Caminho instalado:
     <string name="session_drawer_rts_gestures">Gestos RTS</string>
     <string name="session_drawer_rts_gestures_edit">Editar</string>
     <string name="session_drawer_touch">Toque</string>
+    <string name="session_drawer_layout">Layout da gaveta</string>
+    <string name="session_drawer_layout_items">Itens do menu</string>
+    <string name="session_drawer_layout_tabs">Abas</string>
     <string name="session_drawer_touch_map_right_stick">Mapear para o analógico direito</string>
     <string name="session_drawer_touch_touchscreen">Modo Tela Sensível ao Toque</string>
     <string name="session_drawer_touch_trackpad">Trackpad</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -677,6 +677,9 @@ Por ex. <b>META</b> para <i>tecla META</i>, \n
     <string name="session_drawer_relative_mouse_movement">Movimento Relativo do Rato</string>
     <string name="session_drawer_mouse_input">Entrada do Rato</string>
     <string name="session_drawer_touch">Toque</string>
+    <string name="session_drawer_layout">Layout da gaveta</string>
+    <string name="session_drawer_layout_items">Itens de menu</string>
+    <string name="session_drawer_layout_tabs">Abas</string>
     <string name="session_drawer_touch_trackpad">Trackpad</string>
     <string name="session_drawer_touch_touchscreen">Modo de Ecrã Tátil</string>
     <string name="session_drawer_touch_map_right_stick">Mapear para o Manípulo Direito</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1510,6 +1510,9 @@ Cale instalata:
     <string name="session_drawer_rts_gestures">Gesturi RTS</string>
     <string name="session_drawer_rts_gestures_edit">Editează</string>
     <string name="session_drawer_touch">Tactil</string>
+    <string name="session_drawer_layout">Aspectul sertarului</string>
+    <string name="session_drawer_layout_items">Elemente de meniu</string>
+    <string name="session_drawer_layout_tabs">File</string>
     <string name="session_drawer_touch_map_right_stick">Mapează pe stick dreapta</string>
     <string name="session_drawer_touch_touchscreen">Mod ecran tactil</string>
     <string name="session_drawer_touch_trackpad">Trackpad</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1417,6 +1417,9 @@
     <string name="session_drawer_rts_gestures">Жесты RTS</string>
     <string name="session_drawer_rts_gestures_edit">Изменить</string>
     <string name="session_drawer_touch">Касание</string>
+    <string name="session_drawer_layout">Раскладка панели</string>
+    <string name="session_drawer_layout_items">Элементы меню</string>
+    <string name="session_drawer_layout_tabs">Вкладки</string>
     <string name="session_drawer_touch_map_right_stick">Назначить на правый стик</string>
     <string name="session_drawer_touch_touchscreen">Режим сенсорного экрана</string>
     <string name="session_drawer_touch_trackpad">Трекпад</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -677,6 +677,9 @@ T.ex. <b>META</b> för <i>META-tangent</i>, \n
     <string name="session_drawer_relative_mouse_movement">Relativ musrörelse</string>
     <string name="session_drawer_mouse_input">Musinmatning</string>
     <string name="session_drawer_touch">Touch</string>
+    <string name="session_drawer_layout">Lådans layout</string>
+    <string name="session_drawer_layout_items">Menyalternativ</string>
+    <string name="session_drawer_layout_tabs">Flikar</string>
     <string name="session_drawer_touch_trackpad">Styrplatta</string>
     <string name="session_drawer_touch_touchscreen">Pekskärmsläge</string>
     <string name="session_drawer_touch_map_right_stick">Mappa till höger spak</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -677,6 +677,9 @@
     <string name="session_drawer_relative_mouse_movement">การเคลื่อนเมาส์แบบสัมพัทธ์</string>
     <string name="session_drawer_mouse_input">อินพุตเมาส์</string>
     <string name="session_drawer_touch">สัมผัส</string>
+    <string name="session_drawer_layout">เค้าโครงแผง</string>
+    <string name="session_drawer_layout_items">รายการเมนู</string>
+    <string name="session_drawer_layout_tabs">แท็บ</string>
     <string name="session_drawer_touch_trackpad">แทร็คแพด</string>
     <string name="session_drawer_touch_touchscreen">โหมดหน้าจอสัมผัส</string>
     <string name="session_drawer_touch_map_right_stick">แมปกับสติ๊กขวา</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -677,6 +677,9 @@ E.g. <b>META</b> için <i>META tuşu</i>, \n
     <string name="session_drawer_relative_mouse_movement">Göreli Fare Hareketi</string>
     <string name="session_drawer_mouse_input">Fare Girişi</string>
     <string name="session_drawer_touch">Dokunma</string>
+    <string name="session_drawer_layout">Çekmece düzeni</string>
+    <string name="session_drawer_layout_items">Menü öğeleri</string>
+    <string name="session_drawer_layout_tabs">Sekmeler</string>
     <string name="session_drawer_touch_trackpad">Dokunmatik Yüzey</string>
     <string name="session_drawer_touch_touchscreen">Dokunmatik Ekran Modu</string>
     <string name="session_drawer_touch_map_right_stick">Sağ Çubuğa Eşle</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1517,6 +1517,9 @@
     <string name="session_drawer_rts_gestures">RTS-жести</string>
     <string name="session_drawer_rts_gestures_edit">Редагувати</string>
     <string name="session_drawer_touch">Дотик</string>
+    <string name="session_drawer_layout">Макет панелі</string>
+    <string name="session_drawer_layout_items">Пункти меню</string>
+    <string name="session_drawer_layout_tabs">Вкладки</string>
     <string name="session_drawer_touch_map_right_stick">Призначити на правий стік</string>
     <string name="session_drawer_touch_touchscreen">Режим сенсорного екрана</string>
     <string name="session_drawer_touch_trackpad">Тачпад</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1511,6 +1511,7 @@
     <string name="session_drawer_rts_gestures">RTS 手势</string>
     <string name="session_drawer_rts_gestures_edit">编辑</string>
     <string name="session_drawer_touch">触摸</string>
+    <string name="session_drawer_layout">抽屉布局</string>
     <string name="session_drawer_touch_map_right_stick">映射到右摇杆</string>
     <string name="session_drawer_touch_touchscreen">触摸屏模式</string>
     <string name="session_drawer_touch_trackpad">触控板</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1512,6 +1512,8 @@
     <string name="session_drawer_rts_gestures_edit">编辑</string>
     <string name="session_drawer_touch">触摸</string>
     <string name="session_drawer_layout">抽屉布局</string>
+    <string name="session_drawer_layout_items">菜单项</string>
+    <string name="session_drawer_layout_tabs">选项卡</string>
     <string name="session_drawer_touch_map_right_stick">映射到右摇杆</string>
     <string name="session_drawer_touch_touchscreen">触摸屏模式</string>
     <string name="session_drawer_touch_trackpad">触控板</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1510,6 +1510,9 @@
     <string name="session_drawer_rts_gestures">RTS 手勢</string>
     <string name="session_drawer_rts_gestures_edit">編輯</string>
     <string name="session_drawer_touch">觸控</string>
+    <string name="session_drawer_layout">抽屜版面</string>
+    <string name="session_drawer_layout_items">選單項目</string>
+    <string name="session_drawer_layout_tabs">索引標籤</string>
     <string name="session_drawer_touch_map_right_stick">對應至右搖桿</string>
     <string name="session_drawer_touch_touchscreen">觸控螢幕模式</string>
     <string name="session_drawer_touch_trackpad">觸控板</string>

--- a/app/src/main/res/values/refs.xml
+++ b/app/src/main/res/values/refs.xml
@@ -22,6 +22,7 @@
     <item type="id" name="main_menu_relative_mouse_movement" />
     <item type="id" name="main_menu_disable_mouse" />
     <item type="id" name="main_menu_touch" />
+    <item type="id" name="main_menu_drawer_layout" />
     <item type="id" name="main_menu_toggle_fullscreen" />
     <item type="id" name="main_menu_screen_effects" />
     <item type="id" name="main_menu_frame_generation" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -722,6 +722,8 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="session_drawer_mouse_input">Mouse Input</string>
     <string name="session_drawer_touch">Touch</string>
     <string name="session_drawer_layout">Drawer Layout</string>
+    <string name="session_drawer_layout_items">Menu Items</string>
+    <string name="session_drawer_layout_tabs">Tabs</string>
     <string name="session_drawer_touch_trackpad">Trackpad</string>
     <string name="session_drawer_touch_touchscreen">Touchscreen Mode</string>
     <string name="session_drawer_touch_map_right_stick">Map to Right Stick</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -721,6 +721,7 @@ E.g. <b>META</b> for <i>META key</i>, \n
     <string name="session_drawer_relative_mouse_movement">Relative Mouse Movement</string>
     <string name="session_drawer_mouse_input">Mouse Input</string>
     <string name="session_drawer_touch">Touch</string>
+    <string name="session_drawer_layout">Drawer Layout</string>
     <string name="session_drawer_touch_trackpad">Trackpad</string>
     <string name="session_drawer_touch_touchscreen">Touchscreen Mode</string>
     <string name="session_drawer_touch_map_right_stick">Map to Right Stick</string>

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -541,6 +541,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity
     private float drawerEdgeGestureStartX = 0f;
     private float drawerEdgeGestureStartY = 0f;
     private int drawerEdgeGesturePointerId = -1;
+    private com.winlator.cmod.runtime.display.DrawerSide drawerEdgeGestureSide = null;
 
     private SensorManager sensorManager;
     private Sensor gyroSensor;
@@ -4374,10 +4375,14 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity
     }
 
     private void openDrawerMenu() {
+        openDrawerMenu(com.winlator.cmod.runtime.display.DrawerSide.LEFT);
+    }
+
+    private void openDrawerMenu(com.winlator.cmod.runtime.display.DrawerSide side) {
         releasePointerCapture();
         renderDrawerMenu();
         if (drawerStateHolder != null) {
-            drawerStateHolder.openDrawer();
+            drawerStateHolder.openDrawer(side);
         }
         if (touchpadView != null) {
             touchpadView.setOnCapturedPointerListener(null);
@@ -8830,9 +8835,19 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity
                 drawerEdgeGestureStartX = event.getX();
                 drawerEdgeGestureStartY = event.getY();
                 drawerEdgeGesturePointerId = event.getPointerId(0);
+                float edgePx = getDrawerEdgeSwipePx();
+                int screenWidth = getResources().getDisplayMetrics().widthPixels;
+                boolean onLeft = drawerEdgeGestureStartX <= edgePx;
+                boolean onRight = screenWidth > 0 && drawerEdgeGestureStartX >= screenWidth - edgePx;
                 drawerEdgeGesturePossible =
-                        drawerEdgeGestureStartX <= getDrawerEdgeSwipePx()
+                        (onLeft || onRight)
                                 && !isTouchInsideMagnifier(drawerEdgeGestureStartX, drawerEdgeGestureStartY);
+                drawerEdgeGestureSide =
+                        drawerEdgeGesturePossible
+                                ? (onLeft
+                                        ? com.winlator.cmod.runtime.display.DrawerSide.LEFT
+                                        : com.winlator.cmod.runtime.display.DrawerSide.RIGHT)
+                                : null;
                 break;
             }
             case MotionEvent.ACTION_MOVE: {
@@ -8846,18 +8861,34 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity
                 float dx = event.getX(pointerIndex) - drawerEdgeGestureStartX;
                 float dy = event.getY(pointerIndex) - drawerEdgeGestureStartY;
                 int slop = android.view.ViewConfiguration.get(this).getScaledTouchSlop();
+                int trigger = getDrawerOpenTriggerPx();
+                boolean horizontal =
+                        Math.abs(dx) > trigger
+                                && Math.abs(dx)
+                                        > Math.abs(dy)
+                                                * XServerDisplayHostKt.XSERVER_DRAWER_OPEN_HORIZONTAL_RATIO;
+                boolean openLeft =
+                        drawerEdgeGestureSide == com.winlator.cmod.runtime.display.DrawerSide.LEFT
+                                && dx > 0
+                                && horizontal;
+                boolean openRight =
+                        drawerEdgeGestureSide == com.winlator.cmod.runtime.display.DrawerSide.RIGHT
+                                && dx < 0
+                                && horizontal;
 
-                if (dx > getDrawerOpenTriggerPx()
-                        && dx > Math.abs(dy) * XServerDisplayHostKt.XSERVER_DRAWER_OPEN_HORIZONTAL_RATIO) {
+                if (openLeft || openRight) {
                     if (touchpadView != null) {
                         touchpadView.resetInputState();
                     }
                     if (inputControlsView != null) {
                         inputControlsView.cancelActiveTouches();
                     }
-                    openDrawerMenu();
+                    openDrawerMenu(
+                            openLeft
+                                    ? com.winlator.cmod.runtime.display.DrawerSide.LEFT
+                                    : com.winlator.cmod.runtime.display.DrawerSide.RIGHT);
                     resetDrawerEdgeGesture();
-                } else if (Math.abs(dy) > slop && Math.abs(dy) > dx) {
+                } else if (Math.abs(dy) > slop && Math.abs(dy) > Math.abs(dx)) {
                     resetDrawerEdgeGesture();
                 }
                 break;
@@ -8889,6 +8920,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity
     private void resetDrawerEdgeGesture() {
         drawerEdgeGesturePossible = false;
         drawerEdgeGesturePointerId = -1;
+        drawerEdgeGestureSide = null;
     }
 
     @Override

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -1565,9 +1565,14 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity
             final int edgePx = (int) (XServerDisplayHostKt.XSERVER_DRAWER_EDGE_SWIPE_DP * getResources().getDisplayMetrics().density);
             final Runnable applyExclusion = () -> {
                 if (gestureExclusionView.getHeight() <= 0) return;
-                gestureExclusionView.setSystemGestureExclusionRects(
-                        java.util.Collections.singletonList(
-                                new android.graphics.Rect(0, 0, edgePx, gestureExclusionView.getHeight())));
+                int height = gestureExclusionView.getHeight();
+                int width = gestureExclusionView.getWidth();
+                java.util.ArrayList<android.graphics.Rect> rects = new java.util.ArrayList<>();
+                rects.add(new android.graphics.Rect(0, 0, edgePx, height));
+                if (width > 0) {
+                    rects.add(new android.graphics.Rect(width - edgePx, 0, width, height));
+                }
+                gestureExclusionView.setSystemGestureExclusionRects(rects);
             };
             gestureExclusionView.post(applyExclusion);
             gestureExclusionView.addOnLayoutChangeListener((v, l, t, r, b, ol, ot, or_, ob) -> applyExclusion.run());

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -1555,7 +1555,23 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity
         getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
             @Override
             public void handleOnBackPressed() {
-                handleNavigationBackPressed();
+                // Back closes overlay → pane → drawer, and NEVER opens the drawer. With
+                // nothing open, defer to the default back behavior (exit/minimize) by
+                // temporarily disabling this callback and re-dispatching.
+                if (drawerStateHolder != null && drawerStateHolder.consumeOverlayBack()) {
+                    return;
+                }
+                if (drawerStateHolder != null && drawerStateHolder.isPaneOpen()) {
+                    drawerStateHolder.closeOpenPane();
+                    return;
+                }
+                if (drawerStateHolder != null && drawerStateHolder.isDrawerOpen()) {
+                    closeDrawerMenu();
+                    return;
+                }
+                setEnabled(false);
+                getOnBackPressedDispatcher().onBackPressed();
+                setEnabled(true);
             }
         });
 
@@ -4364,18 +4380,17 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity
     }
 
     private void handleNavigationBackPressed() {
-        if (environment != null) {
-            if (drawerStateHolder != null && drawerStateHolder.consumeOverlayBack()) {
-                return;
-            }
-            if (drawerStateHolder != null && drawerStateHolder.isPaneOpen()) {
-                drawerStateHolder.closeOpenPane();
-                return;
-            }
-            if (drawerStateHolder == null || !drawerStateHolder.isDrawerOpen()) {
-                openDrawerMenu();
-            }
-            else closeDrawerMenu();
+        // Back closes overlay → pane → drawer, and NEVER opens the drawer.
+        if (environment == null) return;
+        if (drawerStateHolder != null && drawerStateHolder.consumeOverlayBack()) {
+            return;
+        }
+        if (drawerStateHolder != null && drawerStateHolder.isPaneOpen()) {
+            drawerStateHolder.closeOpenPane();
+            return;
+        }
+        if (drawerStateHolder != null && drawerStateHolder.isDrawerOpen()) {
+            closeDrawerMenu();
         }
     }
 

--- a/app/src/main/runtime/display/XServerDisplayActivity.java
+++ b/app/src/main/runtime/display/XServerDisplayActivity.java
@@ -1555,9 +1555,9 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity
         getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
             @Override
             public void handleOnBackPressed() {
-                // Back closes overlay → pane → drawer, and NEVER opens the drawer. With
-                // nothing open, defer to the default back behavior (exit/minimize) by
-                // temporarily disabling this callback and re-dispatching.
+                // Back only closes overlay → pane → drawer. With nothing open it is
+                // swallowed entirely: never opens the drawer and never exits the
+                // container while a game is running.
                 if (drawerStateHolder != null && drawerStateHolder.consumeOverlayBack()) {
                     return;
                 }
@@ -1567,11 +1567,7 @@ public class XServerDisplayActivity extends FixedFontScaleAppCompatActivity
                 }
                 if (drawerStateHolder != null && drawerStateHolder.isDrawerOpen()) {
                     closeDrawerMenu();
-                    return;
                 }
-                setEnabled(false);
-                getOnBackPressedDispatcher().onBackPressed();
-                setEnabled(true);
             }
         });
 

--- a/app/src/main/runtime/display/XServerDisplayHost.kt
+++ b/app/src/main/runtime/display/XServerDisplayHost.kt
@@ -56,19 +56,24 @@ import kotlinx.coroutines.launch
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
-const val XSERVER_DRAWER_EDGE_SWIPE_DP = 12
+const val XSERVER_DRAWER_EDGE_SWIPE_DP = 24
 
 // Horizontal swipe distance to open the drawer; shared with XServerDisplayActivity.
-const val XSERVER_DRAWER_OPEN_TRIGGER_DP = 32
+// 16dp: a short swipe from the edge reliably opens (was 32dp) so you no longer have to
+// drag toward the middle for the drawer to appear.
+const val XSERVER_DRAWER_OPEN_TRIGGER_DP = 16
 
-// Open only on a clearly rightward swipe: dx must exceed this * |dy| (~27deg of horizontal).
-const val XSERVER_DRAWER_OPEN_HORIZONTAL_RATIO = 2f
+// Open only on a clearly horizontal swipe: dx must exceed this * |dy| (~27deg of horizontal).
+// 1.5f: tolerate a slightly diagonal swipe (was 2f) so an imperfect angle doesn't bounce back.
+const val XSERVER_DRAWER_OPEN_HORIZONTAL_RATIO = 1.5f
 
 private val DrawerWidth = 300.dp
 private val DrawerStartPadding = 6.dp
 private val DrawerVerticalPadding = 6.dp
 private const val DrawerSettleAnimationMs = 200
-private const val DrawerOpenSettleThreshold = 0.4f
+// 0.3f: dragging out ~1/3 of the drawer now keeps it open (was 0.4f), so a slightly
+// short swipe settles open instead of snapping back.
+private const val DrawerOpenSettleThreshold = 0.3f
 private const val DrawerCloseSettleThreshold = 0.65f
 private val DrawerSettleAnimationSpec =
     tween<Float>(
@@ -248,7 +253,12 @@ private fun XServerDisplayHost(
                                 totalDy += delta.y
 
                                 if (!gestureClaimed) {
-                                    if (abs(totalDy) > viewConfiguration.touchSlop && abs(totalDy) > abs(totalDx)) {
+                                    // Only an *obviously* vertical drag cancels the gesture; a slightly
+                                    // diagonal swipe (dy up to 2x dx) still counts as horizontal so a
+                                    // not-quite-straight swipe opens instead of bouncing back.
+                                    if (abs(totalDy) > viewConfiguration.touchSlop &&
+                                        abs(totalDy) > abs(totalDx) * 2f
+                                    ) {
                                         cancelledByVerticalDrag = true
                                         break
                                     }

--- a/app/src/main/runtime/display/XServerDisplayHost.kt
+++ b/app/src/main/runtime/display/XServerDisplayHost.kt
@@ -56,7 +56,7 @@ import kotlinx.coroutines.launch
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
-const val XSERVER_DRAWER_EDGE_SWIPE_DP = 35
+const val XSERVER_DRAWER_EDGE_SWIPE_DP = 12
 
 // Horizontal swipe distance to open the drawer; shared with XServerDisplayActivity.
 const val XSERVER_DRAWER_OPEN_TRIGGER_DP = 32
@@ -343,7 +343,18 @@ private fun XServerDisplayHost(
             }
 
             // Closed, the sheet sits flush on the edge and its rounded corners leak a hairline.
-            val openRight = stateHolder.openSide == com.winlator.cmod.runtime.display.DrawerSide.RIGHT
+            var lastSide by remember {
+                androidx.compose.runtime.mutableStateOf<com.winlator.cmod.runtime.display.DrawerSide?>(
+                    null,
+                )
+            }
+            LaunchedEffect(stateHolder.openSide) {
+                if (stateHolder.openSide != null) {
+                    lastSide = stateHolder.openSide
+                }
+            }
+            val openRight =
+                (stateHolder.openSide ?: lastSide) == com.winlator.cmod.runtime.display.DrawerSide.RIGHT
             if (drawerContentComposed) {
                 ModalDrawerSheet(
                     drawerShape = RoundedCornerShape(20.dp),

--- a/app/src/main/runtime/display/XServerDisplayHost.kt
+++ b/app/src/main/runtime/display/XServerDisplayHost.kt
@@ -71,9 +71,11 @@ private val DrawerWidth = 300.dp
 private val DrawerStartPadding = 6.dp
 private val DrawerVerticalPadding = 6.dp
 private const val DrawerSettleAnimationMs = 200
-// 0.3f: dragging out ~1/3 of the drawer now keeps it open (was 0.4f), so a slightly
-// short swipe settles open instead of snapping back.
-private const val DrawerOpenSettleThreshold = 0.3f
+// Dragging out any visible amount of the drawer keeps it open. The settle check is
+// drawerProgress >= this, and progress = draggedPx / drawerWidthPx (~300dp), so 0 means
+// “as soon as the gesture was claimed (past the open trigger) it stays open”; a positive
+// value would again bounce back for anything dragged less than threshold × width.
+private const val DrawerOpenSettleThreshold = 0f
 private const val DrawerCloseSettleThreshold = 0.65f
 private val DrawerSettleAnimationSpec =
     tween<Float>(

--- a/app/src/main/runtime/display/XServerDisplayHost.kt
+++ b/app/src/main/runtime/display/XServerDisplayHost.kt
@@ -118,6 +118,10 @@ private fun XServerDisplayHost(
     val animationScope = rememberCoroutineScope()
     val density = LocalDensity.current
     val viewConfiguration = LocalViewConfiguration.current
+    val screenWidthPx =
+        with(density) {
+            androidx.compose.ui.platform.LocalConfiguration.current.screenWidthDp.dp.toPx()
+        }
     val closedFallbackPx = with(density) { -(DrawerWidth + DrawerStartPadding).toPx() }
     var drawerOffsetPx by remember { mutableFloatStateOf(closedFallbackPx) }
     var drawerWidthPx by remember { mutableFloatStateOf(0f) }
@@ -128,6 +132,16 @@ private fun XServerDisplayHost(
             closedFallbackPx
         }
     val drawerOpenOffset = 0f
+    var lastSide by remember {
+        androidx.compose.runtime.mutableStateOf<com.winlator.cmod.runtime.display.DrawerSide?>(
+            null,
+        )
+    }
+    LaunchedEffect(stateHolder.openSide) {
+        if (stateHolder.openSide != null) {
+            lastSide = stateHolder.openSide
+        }
+    }
     // "Engaged" = on or sliding onto the screen; drives the card-reveal animation (the content itself is always composed).
     val drawerEngaged = drawerWidthPx <= 0f ||
         drawerOffsetPx > drawerClosedOffset + 1f ||
@@ -150,7 +164,6 @@ private fun XServerDisplayHost(
     }
 
     LaunchedEffect(stateHolder.isDrawerOpen, drawerWidthPx) {
-        if (drawerWidthPx <= 0f) return@LaunchedEffect
         val target = if (stateHolder.isDrawerOpen) drawerOpenOffset else drawerClosedOffset
         if (drawerOffsetPx != target) {
             callbacks.onDrawerSlide()
@@ -191,17 +204,30 @@ private fun XServerDisplayHost(
 
                             val edgeWidthPx = XSERVER_DRAWER_EDGE_SWIPE_DP.dp.toPx()
                             val openTriggerPx = XSERVER_DRAWER_OPEN_TRIGGER_DP.dp.toPx()
+                            val drawerOpen = stateHolder.isDrawerOpen
+                            val sheetAtRight =
+                                (stateHolder.openSide ?: lastSide) ==
+                                    com.winlator.cmod.runtime.display.DrawerSide.RIGHT
+                            val sheetLeftPx = screenWidthPx - drawerWidthPx
                             val canStartFromHere =
-                                if (stateHolder.isDrawerOpen) {
-                                    down.position.x >= drawerWidthPx &&
-                                        down.position.x <= drawerWidthPx + edgeWidthPx
+                                if (drawerOpen) {
+                                    if (sheetAtRight) {
+                                        down.position.x >= sheetLeftPx - edgeWidthPx &&
+                                            down.position.x <= sheetLeftPx
+                                    } else {
+                                        down.position.x >= drawerWidthPx &&
+                                            down.position.x <= drawerWidthPx + edgeWidthPx
+                                    }
                                 } else {
-                                    down.position.x <= edgeWidthPx
+                                    down.position.x <= edgeWidthPx ||
+                                        down.position.x >= screenWidthPx - edgeWidthPx
                                 }
                             if (!canStartFromHere) {
-                                if (stateHolder.isDrawerOpen && down.position.x > drawerWidthPx
-                                    && !callbacks.isControllerConnected()) {
-                                    stateHolder.closeDrawer()
+                                if (drawerOpen && !callbacks.isControllerConnected()) {
+                                    val outside =
+                                        if (sheetAtRight) down.position.x < sheetLeftPx
+                                        else down.position.x > drawerWidthPx
+                                    if (outside) stateHolder.closeDrawer()
                                 }
                                 return@awaitEachGesture
                             }
@@ -228,10 +254,16 @@ private fun XServerDisplayHost(
                                     }
                                     val horizontalDragClaimed =
                                         if (stateHolder.isDrawerOpen) {
-                                            totalDx < -viewConfiguration.touchSlop && abs(totalDx) > abs(totalDy)
+                                            val closeDx = if (sheetAtRight) totalDx > 0f else totalDx < 0f
+                                            abs(totalDx) > viewConfiguration.touchSlop &&
+                                                abs(totalDx) > abs(totalDy) &&
+                                                closeDx
                                         } else {
-                                            totalDx > openTriggerPx &&
-                                                totalDx > abs(totalDy) * XSERVER_DRAWER_OPEN_HORIZONTAL_RATIO
+                                            val openDx = if (sheetAtRight) totalDx < 0f else totalDx > 0f
+                                            abs(totalDx) > openTriggerPx &&
+                                                abs(totalDx) >
+                                                    abs(totalDy) * XSERVER_DRAWER_OPEN_HORIZONTAL_RATIO &&
+                                                openDx
                                         }
                                     if (horizontalDragClaimed) {
                                         gestureClaimed = true
@@ -343,16 +375,6 @@ private fun XServerDisplayHost(
             }
 
             // Closed, the sheet sits flush on the edge and its rounded corners leak a hairline.
-            var lastSide by remember {
-                androidx.compose.runtime.mutableStateOf<com.winlator.cmod.runtime.display.DrawerSide?>(
-                    null,
-                )
-            }
-            LaunchedEffect(stateHolder.openSide) {
-                if (stateHolder.openSide != null) {
-                    lastSide = stateHolder.openSide
-                }
-            }
             val openRight =
                 (stateHolder.openSide ?: lastSide) == com.winlator.cmod.runtime.display.DrawerSide.RIGHT
             if (drawerContentComposed) {
@@ -388,8 +410,9 @@ private fun XServerDisplayHost(
                         listener = listener,
                         onDismiss = { stateHolder.closeDrawer() },
                         openSide = stateHolder.openSide,
-                        onDrawerLayoutChanged = { newItems ->
-                            stateHolder.state = stateHolder.state.copy(items = newItems)
+                        onDrawerLayoutChanged = { newItems, newPaneSides ->
+                            stateHolder.state =
+                                stateHolder.state.copy(items = newItems, paneSides = newPaneSides)
                         },
                         revealCards = drawerEngaged,
                         menuNavRegion = stateHolder.menuNavRegion,

--- a/app/src/main/runtime/display/XServerDisplayHost.kt
+++ b/app/src/main/runtime/display/XServerDisplayHost.kt
@@ -343,6 +343,7 @@ private fun XServerDisplayHost(
             }
 
             // Closed, the sheet sits flush on the edge and its rounded corners leak a hairline.
+            val openRight = stateHolder.openSide == com.winlator.cmod.runtime.display.DrawerSide.RIGHT
             if (drawerContentComposed) {
                 ModalDrawerSheet(
                     drawerShape = RoundedCornerShape(20.dp),
@@ -353,14 +354,18 @@ private fun XServerDisplayHost(
                     modifier =
                         Modifier
                             .zIndex(2f)
-                            .padding(start = DrawerStartPadding, top = drawerTopInset, bottom = DrawerVerticalPadding)
+                            .then(if (openRight) Modifier.align(Alignment.CenterEnd) else Modifier)
+                            .padding(
+                                start = if (openRight) 0.dp else DrawerStartPadding,
+                                end = if (openRight) DrawerStartPadding else 0.dp,
+                                top = drawerTopInset,
+                                bottom = DrawerVerticalPadding,
+                            )
                             .fillMaxHeight()
                             .width(scaledDrawerWidth)
                             .offset {
-                                androidx.compose.ui.unit.IntOffset(
-                                    drawerOffsetPx.roundToInt(),
-                                    0,
-                                )
+                                val dx = drawerOffsetPx.roundToInt()
+                                androidx.compose.ui.unit.IntOffset(if (openRight) -dx else dx, 0)
                             },
                 ) {
                     XServerDrawerContent(
@@ -371,6 +376,10 @@ private fun XServerDisplayHost(
                         onOpenPaneChange = { stateHolder.setOpenPaneAndNotify(it) },
                         listener = listener,
                         onDismiss = { stateHolder.closeDrawer() },
+                        openSide = stateHolder.openSide,
+                        onDrawerLayoutChanged = { newItems ->
+                            stateHolder.state = stateHolder.state.copy(items = newItems)
+                        },
                         revealCards = drawerEngaged,
                         menuNavRegion = stateHolder.menuNavRegion,
                         menuNavIndex = stateHolder.menuNavIndex,

--- a/app/src/main/runtime/display/XServerDisplayHost.kt
+++ b/app/src/main/runtime/display/XServerDisplayHost.kt
@@ -397,7 +397,9 @@ private fun XServerDisplayHost(
                             .fillMaxHeight()
                             .width(scaledDrawerWidth)
                             .offset {
-                                val dx = drawerOffsetPx.roundToInt()
+                                val effective =
+                                    if (stateHolder.isDrawerOpen) drawerOffsetPx else drawerClosedOffset
+                                val dx = effective.roundToInt()
                                 androidx.compose.ui.unit.IntOffset(if (openRight) -dx else dx, 0)
                             },
                 ) {

--- a/app/src/main/runtime/display/XServerDrawerMenu.kt
+++ b/app/src/main/runtime/display/XServerDrawerMenu.kt
@@ -2257,6 +2257,33 @@ private fun DrawerLayoutDialog(
     val context = androidx.compose.ui.platform.LocalContext.current
     var menuSides by remember { mutableStateOf(items.associate { it.itemId to it.side }) }
     var paneMap by remember { mutableStateOf(paneSides.toMutableMap()) }
+    var activeTab by remember { mutableStateOf(0) }
+
+    @Composable
+    fun sideRow(title: String, current: DrawerSide, onPick: (DrawerSide) -> Unit) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(text = title, fontSize = 13.sp, modifier = Modifier.weight(1f))
+            DrawerSide.entries.forEach { option ->
+                androidx.compose.material3.RadioButton(
+                    selected = current == option,
+                    onClick = { onPick(option) },
+                )
+                Text(
+                    when (option) {
+                        DrawerSide.LEFT -> "\u2190"
+                        DrawerSide.RIGHT -> "\u2192"
+                        DrawerSide.BOTH -> "\u2194"
+                    },
+                    fontSize = 14.sp,
+                )
+                Spacer(Modifier.width(4.dp))
+            }
+        }
+    }
+
     androidx.compose.ui.window.Dialog(onDismissRequest = onDismiss) {
         androidx.compose.material3.Surface(
             shape = androidx.compose.foundation.shape.RoundedCornerShape(12.dp),
@@ -2275,59 +2302,32 @@ private fun DrawerLayoutDialog(
                     fontWeight = FontWeight.Bold,
                 )
                 Spacer(Modifier.height(10.dp))
-
-                Text(
-                    text = stringResource(R.string.session_drawer_layout_items),
-                    fontSize = 14.sp,
-                    fontWeight = FontWeight.Medium,
-                )
-
-                @Composable
-                fun sideRow(title: String, current: DrawerSide, onPick: (DrawerSide) -> Unit) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = title,
-                            fontSize = 13.sp,
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    listOf(
+                        stringResource(R.string.session_drawer_layout_items),
+                        stringResource(R.string.session_drawer_layout_tabs),
+                    ).forEachIndexed { index, label ->
+                        androidx.compose.material3.FilterChip(
+                            selected = activeTab == index,
+                            onClick = { activeTab = index },
+                            label = { Text(label) },
                             modifier = Modifier.weight(1f),
                         )
-                        DrawerSide.entries.forEach { option ->
-                            androidx.compose.material3.RadioButton(
-                                selected = current == option,
-                                onClick = { onPick(option) },
-                            )
-                            Text(
-                                when (option) {
-                                    DrawerSide.LEFT -> "←"
-                                    DrawerSide.RIGHT -> "→"
-                                    DrawerSide.BOTH -> "↔"
-                                },
-                                fontSize = 14.sp,
-                            )
-                            Spacer(Modifier.width(4.dp))
+                    }
+                }
+                Spacer(Modifier.height(10.dp))
+
+                if (activeTab == 0) {
+                    items.forEach { item ->
+                        sideRow(item.title, menuSides[item.itemId] ?: DrawerSide.LEFT) {
+                            menuSides = menuSides + (item.itemId to it)
                         }
                     }
-                }
-
-                items.forEach { item ->
-                    sideRow(item.title, menuSides[item.itemId] ?: DrawerSide.LEFT) {
-                        menuSides = menuSides + (item.itemId to it)
-                    }
-                }
-
-                Spacer(Modifier.height(12.dp))
-                Text(
-                    text = stringResource(R.string.session_drawer_layout_tabs),
-                    fontSize = 14.sp,
-                    fontWeight = FontWeight.Medium,
-                )
-                RAIL_PANES.forEach { spec ->
-                    val visible = items.any { it.itemId == spec.itemId }
-                    if (visible) {
-                        val label = runCatching { context.getString(spec.labelRes) }.getOrNull()
-                            ?: spec.pane?.name ?: ""
+                } else {
+                    RAIL_PANES.forEach { spec ->
+                        val label =
+                            runCatching { context.getString(spec.labelRes) }.getOrNull()
+                                ?: spec.pane?.name ?: ""
                         sideRow(label, paneMap[spec.itemId] ?: DrawerSide.LEFT) {
                             paneMap[spec.itemId] = it
                         }
@@ -2351,6 +2351,7 @@ private fun DrawerLayoutDialog(
         }
     }
 }
+
 
 @Composable
 private fun ActionCard(

--- a/app/src/main/runtime/display/XServerDrawerMenu.kt
+++ b/app/src/main/runtime/display/XServerDrawerMenu.kt
@@ -2256,7 +2256,14 @@ private fun DrawerLayoutDialog(
                                 selected = side == option,
                                 onClick = { sides = sides + (item.itemId to option) },
                             )
-                            Text(option.name.take(1), fontSize = 11.sp)
+                            Text(
+                                when (option) {
+                                    DrawerSide.LEFT -> "←"
+                                    DrawerSide.RIGHT -> "→"
+                                    DrawerSide.BOTH -> "↔"
+                                },
+                                fontSize = 14.sp,
+                            )
                             Spacer(Modifier.width(4.dp))
                         }
                     }

--- a/app/src/main/runtime/display/XServerDrawerMenu.kt
+++ b/app/src/main/runtime/display/XServerDrawerMenu.kt
@@ -2256,7 +2256,7 @@ private fun DrawerLayoutDialog(
 ) {
     val context = androidx.compose.ui.platform.LocalContext.current
     var menuSides by remember { mutableStateOf(items.associate { it.itemId to it.side }) }
-    var paneMap by remember { mutableStateOf(paneSides.toMutableMap()) }
+    var paneMap by remember { mutableStateOf(paneSides) }
     var activeTab by remember { mutableStateOf(0) }
 
     @Composable
@@ -2329,7 +2329,10 @@ private fun DrawerLayoutDialog(
                             runCatching { context.getString(spec.labelRes) }.getOrNull()
                                 ?: spec.pane?.name ?: ""
                         sideRow(label, paneMap[spec.itemId] ?: DrawerSide.LEFT) {
-                            paneMap[spec.itemId] = it
+                            // Rebuild the map instead of mutating in place: Compose only
+                            // recomposes on a new reference, and in-place mutation of a plain
+                            // MutableMap never re-renders the radio selection.
+                            paneMap = paneMap + (spec.itemId to it)
                         }
                     }
                 }

--- a/app/src/main/runtime/display/XServerDrawerMenu.kt
+++ b/app/src/main/runtime/display/XServerDrawerMenu.kt
@@ -599,6 +599,7 @@ data class RecordUiConfig(
 
 data class XServerDrawerState(
     val items: List<XServerDrawerItem>,
+    val paneSides: Map<Int, DrawerSide> = emptyMap(),
     val hudTransparency: Float = 1.0f,
     val hudBackgroundAlphaEnabled: Boolean = false,
     val hudBackgroundTransparency: Float = 1.0f,
@@ -1402,10 +1403,12 @@ fun buildXServerDrawerState(
 
     val itemSideMap = loadDrawerItemSides(context)
     val finalItems = items.map { it.copy(side = itemSideMap[it.itemId] ?: DrawerSide.LEFT) }
+    val paneSides = loadDrawerPaneSides(context)
 
     return XServerDrawerState(
         recordConfig = recordConfig,
         items = finalItems,
+        paneSides = paneSides,
         hudTransparency = hudTransparency,
         hudBackgroundAlphaEnabled = hudBackgroundAlphaEnabled,
         hudBackgroundTransparency = hudBackgroundTransparency,
@@ -1639,7 +1642,7 @@ internal fun XServerDrawerContent(
     listener: XServerDrawerActionListener,
     onDismiss: () -> Unit,
     openSide: DrawerSide? = null,
-    onDrawerLayoutChanged: (List<XServerDrawerItem>) -> Unit = {},
+    onDrawerLayoutChanged: (List<XServerDrawerItem>, Map<Int, DrawerSide>) -> Unit = { _, _ -> },
     revealCards: Boolean = true,
     menuNavRegion: Int = 0,
     menuNavIndex: Int = 0,
@@ -1696,6 +1699,8 @@ internal fun XServerDrawerContent(
                             TopRail(
                                 state = state,
                                 openPane = openPane,
+                                openSide = openSide,
+                                paneSides = state.paneSides,
                                 onTabClick = { spec ->
                                     onOpenPaneChange(if (openPane == spec.pane) null else spec.pane)
                                 },
@@ -1817,6 +1822,8 @@ private data class RailTileBounds(val offsetX: Float, val width: Float, val heig
 private fun TopRail(
     state: XServerDrawerState,
     openPane: DrawerPane?,
+    openSide: DrawerSide? = null,
+    paneSides: Map<Int, DrawerSide> = emptyMap(),
     onTabClick: (RailPaneSpec) -> Unit,
     onMenuClick: () -> Unit,
     region: Int = 0,
@@ -1828,7 +1835,13 @@ private fun TopRail(
 ) {
     val paneScale = LocalPaneScale.current
     val density = LocalDensity.current
-    val activeSpecs = RAIL_PANES.filter { spec -> state.items.any { it.itemId == spec.itemId } }
+    val activeSpecs =
+        RAIL_PANES.filter { spec ->
+            state.items.any { it.itemId == spec.itemId } &&
+                (openSide == null ||
+                    (paneSides[spec.itemId] ?: DrawerSide.LEFT) == openSide ||
+                    (paneSides[spec.itemId] ?: DrawerSide.LEFT) == DrawerSide.BOTH)
+        }
 
     val tabCount = activeSpecs.size + 1
     LaunchedEffect(tabCount) { onSetNavCount(tabCount) }
@@ -2070,7 +2083,7 @@ private fun ActionCardGrid(
     listener: XServerDrawerActionListener,
     cardsRevealed: Boolean,
     openSide: DrawerSide? = null,
-    onDrawerLayoutChanged: (List<XServerDrawerItem>) -> Unit = {},
+    onDrawerLayoutChanged: (List<XServerDrawerItem>, Map<Int, DrawerSide>) -> Unit = { _, _ -> },
     onOpenTaskManager: () -> Unit,
     onOpenLogs: () -> Unit,
     onOpenTouch: () -> Unit,
@@ -2176,19 +2189,25 @@ private fun ActionCardGrid(
                         it.itemId !in PINNED_BOTTOM_ITEM_IDS &&
                         it.itemId != R.id.main_menu_drawer_layout
                 },
+            paneSides = state.paneSides,
             onDismiss = { showDrawerLayout = false },
-            onApply = { sides ->
+            onApply = { menuSides, paneSides ->
                 androidx.preference.PreferenceManager.getDefaultSharedPreferences(gridContext)
                     .edit()
                     .putString(
                         "drawer_item_sides",
-                        sides.entries.joinToString(",") { "${it.key}:${it.value.name}" },
+                        menuSides.entries.joinToString(",") { "${it.key}:${it.value.name}" },
+                    )
+                    .putString(
+                        "drawer_pane_sides",
+                        paneSides.entries.joinToString(",") { "${it.key}:${it.value.name}" },
                     )
                     .apply()
                 onDrawerLayoutChanged(
                     state.items.map { item ->
-                        sides[item.itemId]?.let { item.copy(side = it) } ?: item
+                        menuSides[item.itemId]?.let { item.copy(side = it) } ?: item
                     },
+                    paneSides,
                 )
                 showDrawerLayout = false
             },
@@ -2202,7 +2221,20 @@ private fun loadDrawerItemSides(context: android.content.Context): Map<Int, Draw
             .getString("drawer_item_sides", "")
             .orEmpty()
     if (raw.isBlank()) return emptyMap()
-    return raw.split(",").mapNotNull { seg ->
+    return parseDrawerSides(raw)
+}
+
+private fun loadDrawerPaneSides(context: android.content.Context): Map<Int, DrawerSide> {
+    val raw =
+        androidx.preference.PreferenceManager.getDefaultSharedPreferences(context)
+            .getString("drawer_pane_sides", "")
+            .orEmpty()
+    if (raw.isBlank()) return emptyMap()
+    return parseDrawerSides(raw)
+}
+
+private fun parseDrawerSides(raw: String): Map<Int, DrawerSide> =
+    raw.split(",").mapNotNull { seg ->
         val parts = seg.split(":")
         val id = parts.getOrNull(0)?.toIntOrNull() ?: return@mapNotNull null
         val side =
@@ -2213,15 +2245,18 @@ private fun loadDrawerItemSides(context: android.content.Context): Map<Int, Draw
             }
         id to side
     }.toMap()
-}
+
 
 @Composable
 private fun DrawerLayoutDialog(
     items: List<XServerDrawerItem>,
+    paneSides: Map<Int, DrawerSide> = emptyMap(),
     onDismiss: () -> Unit,
-    onApply: (Map<Int, DrawerSide>) -> Unit,
+    onApply: (Map<Int, DrawerSide>, Map<Int, DrawerSide>) -> Unit,
 ) {
-    var sides by remember { mutableStateOf(items.associate { it.itemId to it.side }) }
+    val context = androidx.compose.ui.platform.LocalContext.current
+    var menuSides by remember { mutableStateOf(items.associate { it.itemId to it.side }) }
+    var paneMap by remember { mutableStateOf(paneSides.toMutableMap()) }
     androidx.compose.ui.window.Dialog(onDismissRequest = onDismiss) {
         androidx.compose.material3.Surface(
             shape = androidx.compose.foundation.shape.RoundedCornerShape(12.dp),
@@ -2240,21 +2275,28 @@ private fun DrawerLayoutDialog(
                     fontWeight = FontWeight.Bold,
                 )
                 Spacer(Modifier.height(10.dp))
-                items.forEach { item ->
+
+                Text(
+                    text = stringResource(R.string.session_drawer_layout_items),
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Medium,
+                )
+
+                @Composable
+                fun sideRow(title: String, current: DrawerSide, onPick: (DrawerSide) -> Unit) {
                     Row(
                         modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Text(
-                            text = item.title,
+                            text = title,
                             fontSize = 13.sp,
                             modifier = Modifier.weight(1f),
                         )
-                        val side = sides[item.itemId] ?: DrawerSide.LEFT
                         DrawerSide.entries.forEach { option ->
                             androidx.compose.material3.RadioButton(
-                                selected = side == option,
-                                onClick = { sides = sides + (item.itemId to option) },
+                                selected = current == option,
+                                onClick = { onPick(option) },
                             )
                             Text(
                                 when (option) {
@@ -2268,6 +2310,30 @@ private fun DrawerLayoutDialog(
                         }
                     }
                 }
+
+                items.forEach { item ->
+                    sideRow(item.title, menuSides[item.itemId] ?: DrawerSide.LEFT) {
+                        menuSides = menuSides + (item.itemId to it)
+                    }
+                }
+
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    text = stringResource(R.string.session_drawer_layout_tabs),
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Medium,
+                )
+                RAIL_PANES.forEach { spec ->
+                    val visible = items.any { it.itemId == spec.itemId }
+                    if (visible) {
+                        val label = runCatching { context.getString(spec.labelRes) }.getOrNull()
+                            ?: spec.pane?.name ?: ""
+                        sideRow(label, paneMap[spec.itemId] ?: DrawerSide.LEFT) {
+                            paneMap[spec.itemId] = it
+                        }
+                    }
+                }
+
                 Spacer(Modifier.height(12.dp))
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -2277,7 +2343,7 @@ private fun DrawerLayoutDialog(
                         Text(stringResource(R.string.common_ui_cancel))
                     }
                     Spacer(Modifier.width(8.dp))
-                    androidx.compose.material3.Button(onClick = { onApply(sides) }) {
+                    androidx.compose.material3.Button(onClick = { onApply(menuSides, paneMap) }) {
                         Text(stringResource(R.string.common_ui_ok))
                     }
                 }

--- a/app/src/main/runtime/display/XServerDrawerMenu.kt
+++ b/app/src/main/runtime/display/XServerDrawerMenu.kt
@@ -575,6 +575,8 @@ internal val FrameGenTargetRates = listOf(60, 90, 120, 144, 165)
 internal const val FrameGenFlowScaleMin = 25
 internal const val FrameGenFlowScaleMax = 100
 
+enum class DrawerSide { LEFT, RIGHT, BOTH }
+
 data class XServerDrawerItem(
     val itemId: Int,
     val title: String,
@@ -582,6 +584,7 @@ data class XServerDrawerItem(
     val icon: ImageVector,
     val active: Boolean = false,
     val enabled: Boolean = true,
+    val side: DrawerSide = DrawerSide.LEFT,
 )
 
 /** Device-filtered options + persisted selections for the Record popup. Quality: 0=Perf,1=Balance,2=Quality. */
@@ -726,6 +729,7 @@ class XServerDrawerStateHolder(
         flushLogsBufferToState()
     }
     private var drawerOpen by mutableStateOf(false)
+    internal var openSide by mutableStateOf<DrawerSide?>(null)
     internal var openPane by mutableStateOf<DrawerPane?>(null)
     var menuNavRegion by mutableStateOf(0)
         private set
@@ -756,8 +760,11 @@ class XServerDrawerStateHolder(
     val isDrawerOpen: Boolean
         get() = drawerOpen
 
-    fun openDrawer() {
+    fun openDrawer() = openDrawer(DrawerSide.LEFT)
+
+    fun openDrawer(side: DrawerSide) {
         drawerOpen = true
+        openSide = side
     }
 
     private fun regionSize(r: Int) = when (r) {
@@ -886,6 +893,7 @@ class XServerDrawerStateHolder(
 
     fun closeDrawer() {
         drawerOpen = false
+        openSide = null
         openPane = null
     }
 
@@ -1384,9 +1392,20 @@ fun buildXServerDrawerState(
             icon = Icons.AutoMirrored.Outlined.ExitToApp,
         )
 
+    items +=
+        XServerDrawerItem(
+            itemId = R.id.main_menu_drawer_layout,
+            title = context.getString(R.string.session_drawer_layout),
+            subtitle = "",
+            icon = Icons.Outlined.Tune,
+        )
+
+    val itemSideMap = loadDrawerItemSides(context)
+    val finalItems = items.map { it.copy(side = itemSideMap[it.itemId] ?: DrawerSide.LEFT) }
+
     return XServerDrawerState(
         recordConfig = recordConfig,
-        items = items,
+        items = finalItems,
         hudTransparency = hudTransparency,
         hudBackgroundAlphaEnabled = hudBackgroundAlphaEnabled,
         hudBackgroundTransparency = hudBackgroundTransparency,
@@ -1619,6 +1638,8 @@ internal fun XServerDrawerContent(
     onOpenPaneChange: (DrawerPane?) -> Unit,
     listener: XServerDrawerActionListener,
     onDismiss: () -> Unit,
+    openSide: DrawerSide? = null,
+    onDrawerLayoutChanged: (List<XServerDrawerItem>) -> Unit = {},
     revealCards: Boolean = true,
     menuNavRegion: Int = 0,
     menuNavIndex: Int = 0,
@@ -1747,6 +1768,8 @@ internal fun XServerDrawerContent(
                                         state = state,
                                         listener = listener,
                                         cardsRevealed = cardsRevealed.value,
+                                        openSide = openSide,
+                                        onDrawerLayoutChanged = onDrawerLayoutChanged,
                                         onOpenTaskManager = { onOpenPaneChange(DrawerPane.TASK_MANAGER) },
                                         onOpenLogs = { onOpenPaneChange(DrawerPane.LOGS) },
                                         onOpenTouch = { onOpenPaneChange(DrawerPane.TOUCH) },
@@ -2046,6 +2069,8 @@ private fun ActionCardGrid(
     state: XServerDrawerState,
     listener: XServerDrawerActionListener,
     cardsRevealed: Boolean,
+    openSide: DrawerSide? = null,
+    onDrawerLayoutChanged: (List<XServerDrawerItem>) -> Unit = {},
     onOpenTaskManager: () -> Unit,
     onOpenLogs: () -> Unit,
     onOpenTouch: () -> Unit,
@@ -2059,14 +2084,19 @@ private fun ActionCardGrid(
     val paneScale = LocalPaneScale.current
     val cards =
         state.items.filter {
-            it.itemId !in RAIL_PANE_ITEM_IDS && it.itemId !in PINNED_BOTTOM_ITEM_IDS
+            it.itemId !in RAIL_PANE_ITEM_IDS &&
+                it.itemId !in PINNED_BOTTOM_ITEM_IDS &&
+                (openSide == null || it.side == openSide || it.side == DrawerSide.BOTH)
         }
     var showRecordSettings by remember { mutableStateOf(false) }
+    var showDrawerLayout by remember { mutableStateOf(false) }
+    val gridContext = androidx.compose.ui.platform.LocalContext.current
 
     fun cardClick(item: XServerDrawerItem) {
         when (item.itemId) {
             R.id.main_menu_task_manager -> onOpenTaskManager()
             R.id.main_menu_logs -> onOpenLogs()
+            R.id.main_menu_drawer_layout -> showDrawerLayout = true
             // Recording: stop if active, otherwise open the settings popup.
             R.id.main_menu_record ->
                 if (item.active) listener.onActionSelected(item.itemId)
@@ -2136,6 +2166,116 @@ private fun ActionCardGrid(
                 listener.onRecordStart(fpsIndex, resIndex, quality, recordUI)
             },
         )
+    }
+
+    if (showDrawerLayout) {
+        DrawerLayoutDialog(
+            items =
+                state.items.filter {
+                    it.itemId !in RAIL_PANE_ITEM_IDS &&
+                        it.itemId !in PINNED_BOTTOM_ITEM_IDS &&
+                        it.itemId != R.id.main_menu_drawer_layout
+                },
+            onDismiss = { showDrawerLayout = false },
+            onApply = { sides ->
+                androidx.preference.PreferenceManager.getDefaultSharedPreferences(gridContext)
+                    .edit()
+                    .putString(
+                        "drawer_item_sides",
+                        sides.entries.joinToString(",") { "${it.key}:${it.value.name}" },
+                    )
+                    .apply()
+                onDrawerLayoutChanged(
+                    state.items.map { item ->
+                        sides[item.itemId]?.let { item.copy(side = it) } ?: item
+                    },
+                )
+                showDrawerLayout = false
+            },
+        )
+    }
+}
+
+private fun loadDrawerItemSides(context: android.content.Context): Map<Int, DrawerSide> {
+    val raw =
+        androidx.preference.PreferenceManager.getDefaultSharedPreferences(context)
+            .getString("drawer_item_sides", "")
+            .orEmpty()
+    if (raw.isBlank()) return emptyMap()
+    return raw.split(",").mapNotNull { seg ->
+        val parts = seg.split(":")
+        val id = parts.getOrNull(0)?.toIntOrNull() ?: return@mapNotNull null
+        val side =
+            when (parts.getOrNull(1)) {
+                "RIGHT" -> DrawerSide.RIGHT
+                "BOTH" -> DrawerSide.BOTH
+                else -> DrawerSide.LEFT
+            }
+        id to side
+    }.toMap()
+}
+
+@Composable
+private fun DrawerLayoutDialog(
+    items: List<XServerDrawerItem>,
+    onDismiss: () -> Unit,
+    onApply: (Map<Int, DrawerSide>) -> Unit,
+) {
+    var sides by remember { mutableStateOf(items.associate { it.itemId to it.side }) }
+    androidx.compose.ui.window.Dialog(onDismissRequest = onDismiss) {
+        androidx.compose.material3.Surface(
+            shape = androidx.compose.foundation.shape.RoundedCornerShape(12.dp),
+            color = androidx.compose.material3.MaterialTheme.colorScheme.surface,
+        ) {
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .verticalScroll(rememberScrollState())
+                        .padding(16.dp),
+            ) {
+                Text(
+                    text = stringResource(R.string.session_drawer_layout),
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold,
+                )
+                Spacer(Modifier.height(10.dp))
+                items.forEach { item ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = item.title,
+                            fontSize = 13.sp,
+                            modifier = Modifier.weight(1f),
+                        )
+                        val side = sides[item.itemId] ?: DrawerSide.LEFT
+                        DrawerSide.entries.forEach { option ->
+                            androidx.compose.material3.RadioButton(
+                                selected = side == option,
+                                onClick = { sides = sides + (item.itemId to option) },
+                            )
+                            Text(option.name.take(1), fontSize = 11.sp)
+                            Spacer(Modifier.width(4.dp))
+                        }
+                    }
+                }
+                Spacer(Modifier.height(12.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    androidx.compose.material3.TextButton(onClick = onDismiss) {
+                        Text(stringResource(R.string.common_ui_cancel))
+                    }
+                    Spacer(Modifier.width(8.dp))
+                    androidx.compose.material3.Button(onClick = { onApply(sides) }) {
+                        Text(stringResource(R.string.common_ui_ok))
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Adds dual edge drawers to the in-game container overlay: the left drawer
and a new right drawer are each reachable with a side-aware edge swipe, and
every menu item / rail tab can be independently assigned to the left edge,
the right edge, or both. A new Drawer Layout dialog (in the main menu)
controls the per-item side assignment with radio buttons, split across two
tabs (Menu Items / Tabs).