### PR TITLE
docs: fix canonical repository clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Designed for enthusiasts and power users, WinNative delivers the full Winlator e
 
 1. **Clone with submodules and pull LFS objects** (Required):
    ```bash
-   git clone --recursive https://github.com/MaxsTechReview/WinNative.git
+   git clone --recursive https://github.com/WinNative-Emu/WinNative.git
    cd WinNative
    git lfs pull                          # fetches imagefs
    git submodule update --init --recursive


### PR DESCRIPTION
Update the build instructions to clone the canonical WinNative repository. The previous URL pointed contributors to a different fork.